### PR TITLE
Sbst2021

### DIFF
--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/DynaMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/DynaMOSA.java
@@ -21,10 +21,12 @@ package org.evosuite.ga.metaheuristics.mosa;
 
 import org.evosuite.Properties;
 import org.evosuite.ga.ChromosomeFactory;
+import org.evosuite.ga.FitnessFunction;
 import org.evosuite.ga.comparators.OnlyCrowdingComparator;
 import org.evosuite.ga.metaheuristics.mosa.structural.MultiCriteriaManager;
 import org.evosuite.ga.operators.ranking.CrowdingDistance;
 import org.evosuite.testcase.TestChromosome;
+import org.evosuite.testcase.TestFitnessFunction;
 import org.evosuite.utils.LoggingUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -184,5 +186,12 @@ public class DynaMOSA extends AbstractMOSA {
 			this.goalsManager.calculateFitness(c, this);
 			this.notifyEvaluation(c);
 		}
+	}
+
+	@Override
+	public List<? extends FitnessFunction<TestChromosome>> getFitnessFunctions() {
+		List<TestFitnessFunction> testFitnessFunctions = new ArrayList<>(goalsManager.getCoveredGoals());
+		testFitnessFunctions.addAll(goalsManager.getUncoveredGoals());
+		return testFitnessFunctions;
 	}
 }

--- a/client/src/main/java/org/evosuite/setup/TestCluster.java
+++ b/client/src/main/java/org/evosuite/setup/TestCluster.java
@@ -1312,7 +1312,7 @@ public class TestCluster {
 		try {
 			cacheGenerators(clazz);
 		} catch (ConstructionFailedException e) {
-			AtMostOnceLogger.error(logger, "Failed to check cache for "+clazz+" : "+e.getMessage());
+			AtMostOnceLogger.warn(logger, "Failed to check cache for "+clazz+" : "+e.getMessage());
 		}
 		if (!generatorCache.containsKey(clazz))
 			return false;

--- a/client/src/main/java/org/evosuite/utils/generic/GenericClass.java
+++ b/client/src/main/java/org/evosuite/utils/generic/GenericClass.java
@@ -1610,6 +1610,11 @@ public class GenericClass implements Serializable {
 			if (!isAssignableTo(type)) {
 				// If the boundary is not assignable it may still be possible
 				// to instantiate the generic to an assignable type
+				if (type instanceof WildcardType){
+					// TODO i don't know exactly how to handle this case, but it is necessary to prevent an Exception
+					isAssignable = false;
+					break;
+				}
 				if (GenericTypeReflector.erase(type).isAssignableFrom(getRawClass())) {
 					Type instanceType = GenericTypeReflector.getExactSuperType(type,
 					                                                           getRawClass());

--- a/runtime/src/main/java/org/evosuite/runtime/sandbox/MSecurityManager.java
+++ b/runtime/src/main/java/org/evosuite/runtime/sandbox/MSecurityManager.java
@@ -1142,6 +1142,7 @@ public class MSecurityManager extends SecurityManager {
 					|| library.startsWith("jaybird") || library.equals("instrument")
 					|| library.startsWith("osxui") || library.contains("libawt_lwawt")
 					|| library.contains("libawt_headless") || library.contains("libawt_xawt")
+					|| library.contains("javalcms")
 					) {
 				return true;
 			}


### PR DESCRIPTION
The changes i have made for the 2021 SBST tool competition.

Short overview of the commits:

1. DynaMosa returns now the FitnessFunctions of its MultiCriteriaManager: b4828d6 (Fixed Issue #9)
2. Special Treatment for WildCards in GenericClass: f00cac5 (Fixed Issue #11)
3. I don't know why this was a error message: cae708a (This was not really an error, since EvoSuite was still able to generate Tests  and made finding errors in stderr more complicated)
4. Added javalcms to allowed libs: 5dfc3d0